### PR TITLE
automated scanning

### DIFF
--- a/DAQ/python/dwaDaq.py
+++ b/DAQ/python/dwaDaq.py
@@ -803,9 +803,8 @@ class MainWindow(qtw.QMainWindow):
     def initPlottingUpdater(self):
         self.plottingTimer = qtc.QTimer()
         self.plottingTimer.timeout.connect(self.updatePlots)
-        self.plottingTimer.setInterval(PLOT_UPDATE_TIME_SEC*1000) # millseconds
+        self.plottingTimer.setInterval(int(PLOT_UPDATE_TIME_SEC*1000)) # millseconds
         self.plottingTimer.start()
-        #self.plottingTimer.start(PLOT_UPDATE_TIME_SEC*1000) # millseconds
         
     def _initTimeseriesData(self):
         self.adcData = {}
@@ -1885,7 +1884,44 @@ class MainWindow(qtw.QMainWindow):
         self._scanButtonEnable(force=True)
         print("startScanThread complete!")
 
+    def startNextScanIfRequested(self):
+        print("Checking if next scan should start automatically...")
+        runAllScans = self.scanCtrlRunAll.isChecked()
+        if not runAllScans:
+            print('"Run all scans" box is not checked... no more scans to run')
+            return
+        #buttonStatus = [btn.isChecked() for btn in self.radioBtns]
+        #print(f'buttonStatus = {buttonStatus}')
+        #print(f'self.radioBtns[-1].isChecked() = {self.radioBtns[-1].isChecked()}')
+        if self.autoScansRemain:
+            self.autoScansRemain = not self.radioBtns[-1].isChecked()
+            self.startScanThread()
+        else:
+            print("final scan has completed...")
+
     @pyqtSlot()
+    def startScanThreadHandler(self):
+        # Launch either one scan or all scans
+        self.autoScansRemain = not self.radioBtns[-1].isChecked()
+        self.startScanThread()
+        ## Get the checkbox status (one or all scans):
+        #runAllScans = self.scanCtrlRunAll.isChecked()
+        #print(f"runAllScans = {runAllScans}")
+        #if not runAllScans:
+        #    self.startScanThread()
+        #
+        #else:
+        #    print("not yet implemented")
+        #    # Get a list of scans to run
+        #    print(self.radioBtns)
+        #    nScans = len(self.radioBtns)
+        #    scansToRun = list(range(nScans))
+        #    for iscan in scansToRun:
+        #        print(f'activating radio button {iscan}')
+        #        self.radioBtns[iscan].setChecked(True)
+        #        self.startScanThread()
+
+            
     def startScanThread(self):
         print("User has requested a new AUTO scan (DWA is IDLE)")
         self.scanType = ScanType.AUTO
@@ -1965,6 +2001,7 @@ class MainWindow(qtw.QMainWindow):
         print("disableRelaysThreadComplete")
         self._setScanButtonAction('START')
         self._scanButtonEnable(force=True)
+        self.startNextScanIfRequested()
 
     def disableRelaysThreadStarting(self):
         self.btnScanCtrl.setStyleSheet("background-color : orange")
@@ -3343,7 +3380,7 @@ class MainWindow(qtw.QMainWindow):
 
             # If this DWA channel does not correspond to an actual wire, then don't update
             # plots in the GUI
-            print(f" regId = {regId}; self.apaChannels = {self.apaChannels}")
+            #print(f" regId = {regId}; self.apaChannels = {self.apaChannels}")
             if (self.scanType == ScanType.AUTO) and (self.apaChannels[regId] is None):
                 return
             
@@ -3485,7 +3522,7 @@ class MainWindow(qtw.QMainWindow):
             for scb in self.scanCtrlButtons:
                 scb.setStyleSheet("background-color : rgb(3,205,0)")#this makes it so buton/row color are the same
                 if scb == self.btnScanCtrl:
-                    scb.setText("Start next scan")
+                    scb.setText("Start selected scan")
                 else:
                     scb.setText("Start scan")
         elif state == 'ABORT':
@@ -3509,7 +3546,8 @@ class MainWindow(qtw.QMainWindow):
             pass
         
         if state == 'START':
-            self.btnScanCtrl.clicked.connect(self.startScanThread)
+            #self.btnScanCtrl.clicked.connect(self.startScanThread)
+            self.btnScanCtrl.clicked.connect(self.startScanThreadHandler)
             self.btnScanCtrlAdv.clicked.connect(self.startScanAdvThread)
         elif state == 'ABORT':
             self.btnScanCtrl.clicked.connect(self.abortScan)

--- a/DAQ/python/dwaDaqUI.ui
+++ b/DAQ/python/dwaDaqUI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1313</width>
-    <height>1071</height>
+    <height>1099</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -391,6 +391,29 @@
                    </property>
                   </widget>
                  </item>
+                 <item row="4" column="0">
+                  <widget class="QLabel" name="layer_label">
+                   <property name="text">
+                    <string>Layer</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="1">
+                  <widget class="QComboBox" name="configLayerComboBox">
+                   <property name="minimumSize">
+                    <size>
+                     <width>60</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>40</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
                  <item row="5" column="0">
                   <widget class="QLabel" name="apaSide">
                    <property name="text">
@@ -687,26 +710,10 @@
                    </property>
                   </widget>
                  </item>
-                 <item row="4" column="1">
-                  <widget class="QComboBox" name="configLayerComboBox">
-                   <property name="minimumSize">
-                    <size>
-                     <width>60</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>40</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="4" column="0">
-                  <widget class="QLabel" name="layer_label">
+                 <item row="15" column="1">
+                  <widget class="QCheckBox" name="scanCtrlRunAll">
                    <property name="text">
-                    <string>Layer</string>
+                    <string>Run all scans</string>
                    </property>
                   </widget>
                  </item>
@@ -1721,7 +1728,7 @@
      <x>0</x>
      <y>0</y>
      <width>1313</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFIle">
@@ -1784,7 +1791,6 @@
   <tabstop>spinBox</tabstop>
   <tabstop>btnConfigureScans</tabstop>
   <tabstop>scanTable</tabstop>
-  <tabstop>btnScanCtrl</tabstop>
   <tabstop>graphicsView</tabstop>
   <tabstop>configFileName</tabstop>
   <tabstop>omitComments_cb</tabstop>

--- a/DAQ/python/dwaDaqUI.ui
+++ b/DAQ/python/dwaDaqUI.ui
@@ -713,7 +713,7 @@
                  <item row="15" column="1">
                   <widget class="QCheckBox" name="scanCtrlRunAll">
                    <property name="text">
-                    <string>Run all scans</string>
+                    <string>Automate scanning</string>
                    </property>
                   </widget>
                  </item>


### PR DESCRIPTION
This branch (dev_gui_runall) allows user to run a sequence of automated scans without user input. Select a row in the Scan Table (Config tab), and ensure that the "Automate scanning" checkbox is checked (below the "Start next Scan" button). The DAQ will run the currently selected scan, and then automatically march through all scans below that scan. e.g. if Scan 3 is selected, then the automated scan will run Scan 3, then 4, then ... all the way up to the last scan. It will not run Scans 1 and 2. This is a feature since the user may run a single scan (first scan) and then wish to auto-scan all remaining scans (but not repeat the first). 

During automated scanning, you can disable auto-starting of the next scan at any time by unchecking the "Run all scans" checkbox. 

Aborting: if you wish to abort only the current scan, then clicking "Abort" button will do that. The next scan will automatically start. If you wish to abort all scans, then uncheck the "Automate scanning" box before clicking "Abort"